### PR TITLE
Added new pathing check to see if it is imported

### DIFF
--- a/testflow.js
+++ b/testflow.js
@@ -6,7 +6,12 @@
 // node testflow mydialog.txt
 const fs = require("fs");
 
-const SourceCodeFile = './sampleskill/index.js';
+SourceCodeFile = './sampleskill/index.js';
+
+if (fs.existsSync('./src/index.js')) {
+	SourceCodeFile = '../src/index.js';
+}
+
 const handlerName =  'handler'; //'lambda_handler'
 
 


### PR DESCRIPTION
Since this isn't a node package, the only way to incorporate this into part of a package is to take out the `index.js` file separately and putting it into whatever folder that's there. This is not ideal as the project would not get the latest version of this file when it gets updated here.

By making this change, it will allow others to add this repository as a submodule instead of having to manually copy-pasting the file. I've used this for [my own alexa skill](https://github.com/binhonglee/dota2-random) and it seems to work [even (and especially) for CI](https://travis-ci.org/binhonglee/dota2-random/builds/447284163).

As for the inconsistencies of pathing (`./src/index.js` and `../src/index.js`), I'm not sure how it works but that's seems to be the only way it works for me.